### PR TITLE
Update thread saving behavior

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -48,12 +48,14 @@ def run():
                     {"title": "Vibration Theory", "abstract": "Frequency and creation", "field": "Physics"},
                 ])
             if st.button("Save Thread"):
-                save_hypothesis({
+                new_entry = {
                     "verse": manual_ref or verses[0]['reference'] if verses else "",
                     "question": prompt,
                     "hypothesis": hypothesis,
                     "timestamp": datetime.utcnow().isoformat(),
-                })
+                }
+                save_hypothesis(new_entry)
+                memory.append(new_entry)
                 st.success("Saved")
 
     st.header("Conversation Thread")


### PR DESCRIPTION
## Summary
- ensure newly saved thread appears immediately in the UI

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_684b0e2a4f788328927678238b06ef4d